### PR TITLE
[bugfix] Fix typo error in spec_augment_pytorch

### DIFF
--- a/SpecAugment/spec_augment_pytorch.py
+++ b/SpecAugment/spec_augment_pytorch.py
@@ -41,7 +41,7 @@ import random
 import matplotlib
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
-from SpecAugment.sparse_image_warp_pytorch import sparse_image_warp
+from specAugment.sparse_image_warp_pytorch import sparse_image_warp
 import torch
 
 


### PR DESCRIPTION
Change module name in `spec_augment_pytorch.py` to fix #11

```diff
- from SpecAugment.sparse_image_warp_pytorch import sparse_image_warp
+ from specAugment.sparse_image_warp_pytorch import sparse_image_warp
```