### PR TITLE
sparse_image_warp import for TensorFlow 2.0

### DIFF
--- a/SpecAugment/spec_augment_tensorflow.py
+++ b/SpecAugment/spec_augment_tensorflow.py
@@ -38,7 +38,7 @@ SS : Switchboard strong
 import librosa
 import librosa.display
 import tensorflow as tf
-from tensorflow.contrib.image import sparse_image_warp
+from tensorflow_addons.image import sparse_image_warp
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/SpecAugment/spec_augment_tensorflow.py
+++ b/SpecAugment/spec_augment_tensorflow.py
@@ -201,5 +201,3 @@ def visualization_tensor_spectrogram(mel_spectrogram, title):
     plt.title(title)
     plt.tight_layout()
     plt.show()
-    plt.savefig('test.png')
-    plt.close()

--- a/SpecAugment/spec_augment_tensorflow.py
+++ b/SpecAugment/spec_augment_tensorflow.py
@@ -65,18 +65,18 @@ def sparse_warp(mel_spectrogram, time_warping_para=80):
     # Step 1 : Time warping
     # Image warping control point setting.
     # Source
-    pt = tf.random_uniform([], time_warping_para, n-time_warping_para, tf.int32) # radnom point along the time axis
+    pt = tf.random.uniform([], time_warping_para, n-time_warping_para, tf.int32) # radnom point along the time axis
     src_ctr_pt_freq = tf.range(v // 2)  # control points on freq-axis
     src_ctr_pt_time = tf.ones_like(src_ctr_pt_freq) * pt  # control points on time-axis
     src_ctr_pts = tf.stack((src_ctr_pt_time, src_ctr_pt_freq), -1)
-    src_ctr_pts = tf.to_float(src_ctr_pts)
+    src_ctr_pts = tf.cast(src_ctr_pts, dtype=tf.float32)
 
     # Destination
-    w = tf.random_uniform([], -time_warping_para, time_warping_para, tf.int32)  # distance
+    w = tf.random.uniform([], -time_warping_para, time_warping_para, tf.int32)  # distance
     dest_ctr_pt_freq = src_ctr_pt_freq
     dest_ctr_pt_time = src_ctr_pt_time + w
     dest_ctr_pts = tf.stack((dest_ctr_pt_time, dest_ctr_pt_freq), -1)
-    dest_ctr_pts = tf.to_float(dest_ctr_pts)
+    dest_ctr_pts = tf.cast(dest_ctr_pts, dtype=tf.float32)
 
     # warp
     source_control_point_locations = tf.expand_dims(src_ctr_pts, 0)  # (1, v//2, 2)
@@ -110,9 +110,9 @@ def frequency_masking(mel_spectrogram, v, frequency_masking_para=27, frequency_m
     n, v = fbank_size[1], fbank_size[2]
 
     for i in range(frequency_mask_num):
-        f = tf.random_uniform([], minval=0, maxval=frequency_masking_para, dtype=tf.int32)
-        v = tf.to_int32(v)
-        f0 = tf.random_uniform([], minval=0, maxval=v-f, dtype=tf.int32)
+        f = tf.random.uniform([], minval=0, maxval=frequency_masking_para, dtype=tf.int32)
+        v = tf.cast(v, dtype=tf.int32)
+        f0 = tf.random.uniform([], minval=0, maxval=v-f, dtype=tf.int32)
 
         # warped_mel_spectrogram[f0:f0 + f, :] = 0
         mask = tf.concat((tf.ones(shape=(1, n, v - f0 - f, 1)),
@@ -120,7 +120,7 @@ def frequency_masking(mel_spectrogram, v, frequency_masking_para=27, frequency_m
                           tf.ones(shape=(1, n, f0, 1)),
                           ), 2)
         mel_spectrogram = mel_spectrogram * mask
-    return tf.to_float(mel_spectrogram)
+    return tf.cast(mel_spectrogram, dtype=tf.float32)
 
 
 def time_masking(mel_spectrogram, tau, time_masking_para=100, time_mask_num=2):
@@ -145,8 +145,8 @@ def time_masking(mel_spectrogram, tau, time_masking_para=100, time_mask_num=2):
 
     # Step 3 : Time masking
     for i in range(time_mask_num):
-        t = tf.random_uniform([], minval=0, maxval=time_masking_para, dtype=tf.int32)
-        t0 = tf.random_uniform([], minval=0, maxval=tau-t, dtype=tf.int32)
+        t = tf.random.uniform([], minval=0, maxval=time_masking_para, dtype=tf.int32)
+        t0 = tf.random.uniform([], minval=0, maxval=tau-t, dtype=tf.int32)
 
         # mel_spectrogram[:, t0:t0 + t] = 0
         mask = tf.concat((tf.ones(shape=(1, n-t0-t, v, 1)),
@@ -154,7 +154,7 @@ def time_masking(mel_spectrogram, tau, time_masking_para=100, time_mask_num=2):
                           tf.ones(shape=(1, t0, v, 1)),
                           ), 1)
         mel_spectrogram = mel_spectrogram * mask
-    return tf.to_float(mel_spectrogram)
+    return tf.cast(mel_spectrogram, dtype=tf.float32)
 
 
 def spec_augment(mel_spectrogram):
@@ -194,10 +194,6 @@ def visualization_tensor_spectrogram(mel_spectrogram, title):
       title(String): plot figure's title
     """
 
-    # session for plotting
-    sess = tf.InteractiveSession()
-    mel_spectrogram = mel_spectrogram.eval()
-
     # Show mel-spectrogram using librosa's specshow.
     plt.figure(figsize=(10, 4))
     librosa.display.specshow(librosa.power_to_db(mel_spectrogram[0, :, :, 0], ref=np.max), y_axis='mel', fmax=8000, x_axis='time')
@@ -205,3 +201,5 @@ def visualization_tensor_spectrogram(mel_spectrogram, title):
     plt.title(title)
     plt.tight_layout()
     plt.show()
+    plt.savefig('test.png')
+    plt.close()


### PR DESCRIPTION
`tensorflow.contrib` has been moved to `tensorflow-addons` (see https://github.com/tensorflow/community/pull/37).

`sparse_image_warp` is now located in `tensorflow_addons.image` (see https://github.com/tensorflow/addons/blob/master/tensorflow_addons/image/sparse_image_warp.py).

To be able to import the library you need Python 3.7, `tensorflow-addons` >= 0.6.0, `tf.nightly` >= 2.0 (for some reason, when I only had tensorflow I couldn't import, I had to install tf.nightly).