### PR TITLE
Use time_warping_para as input to time_warp to control the window size of warping

### DIFF
--- a/SpecAugment/spec_augment_pytorch.py
+++ b/SpecAugment/spec_augment_pytorch.py
@@ -89,7 +89,7 @@ def spec_augment(mel_spectrogram, time_warping_para=80, frequency_masking_para=2
     tau = mel_spectrogram.shape[2]
 
     # Step 1 : Time warping
-    warped_mel_spectrogram = time_warp(mel_spectrogram)
+    warped_mel_spectrogram = time_warp(mel_spectrogram, W=time_warping_para)
 
     # Step 2 : Frequency masking
     for i in range(frequency_mask_num):


### PR DESCRIPTION
In spec_augment_pytorch.py, spec_augment takes as input argument time_warping_para which is the size of the window for time warping. Within spec_augment, time_warp(mel_spectrogram) was called without using time_warping_para as input, hence time warping behaviour was always the same, even if time_warping_para was set to a different value, because time_warp(mel_spectrogram) was using always its default window value which is W=5. I changed spec_augment to use time_warping_para when time_warp is called.